### PR TITLE
Feature/us11 us12

### DIFF
--- a/project/GEDParser.java
+++ b/project/GEDParser.java
@@ -19,7 +19,10 @@ public class GEDParser {
                 case "--no-bigamy":
                     validator = new NoBigamy(validator);
                     break;
-                case "--tablulate":
+                case "--parents-not-too-old":
+                	validator = new ParentsNotTooOld(validator);
+                	break;
+                case "--tabulate":
                     System.out.println(gedFile);
                     break;
                 default:

--- a/project/models/GEDFile.java
+++ b/project/models/GEDFile.java
@@ -18,10 +18,13 @@ import project.interfaces.Tag;
 
 public class GEDFile {
 
-    private Map<String, Individual> individuals = new HashMap<>();
-    private Map<String, Family> families = new HashMap<>();
+    private Map<String, Individual> individuals;
+    private Map<String, Family> families;;
     
     public GEDFile(Individual[] indivs, Family[] fams) {
+    	individuals = new HashMap<String, Individual>();
+    	families = new HashMap<String, Family>();
+    	
     	for (Individual indi : indivs) {
     		individuals.put(indi.getID(), indi);
     	}
@@ -31,6 +34,9 @@ public class GEDFile {
     }
 
     public GEDFile(File file) {
+    	individuals = new HashMap<String, Individual>();
+    	families = new HashMap<String, Family>();
+    	
         Scanner s = null;
 
         try {

--- a/project/models/GEDFile.java
+++ b/project/models/GEDFile.java
@@ -55,7 +55,7 @@ public class GEDFile {
     }
 
     private Individual parseIndividual(List<GEDLine> list, int index, String ID) {
-        Individual indi = new Individual(ID);
+		Individual indi = new Individual(ID);
         Tag dateType = null;
 
         for (int i = index + 1; i < list.size(); i++) {
@@ -78,10 +78,10 @@ public class GEDFile {
                     dateType = Tag.DEAT;
                     break;
                 case FAMC:
-                    indi.addChild(gedLine.getArgs());
+                    indi.addChildFamily(gedLine.getArgs());
                     break;
                 case FAMS:
-                    indi.addSpouse(gedLine.getArgs());
+                    indi.addSpouseFamily(gedLine.getArgs());
                     break;
                 default:
                     break;
@@ -167,8 +167,8 @@ public class GEDFile {
                     (indi.getBirthday() != null) ? dateFmt.format(indi.getBirthday()) : "NA",
                     (indi.getBirthday() != null) ? Long.toString(indi.age()) : "NA",
                     (indi.getBirthday() != null) ? Boolean.toString(indi.alive()) : "NA",
-                    (indi.getDeath() != null) ? dateFmt.format(indi.getDeath()) : "NA", indi.getChildren().toString(),
-                    indi.getSpouse().toString()));
+                    (indi.getDeath() != null) ? dateFmt.format(indi.getDeath()) : "NA", indi.getChildrenFamily().toString(),
+                    indi.getSpouseFamily().toString()));
         }
 
         return new Table(headers, rows);

--- a/project/models/GEDFile.java
+++ b/project/models/GEDFile.java
@@ -20,6 +20,15 @@ public class GEDFile {
 
     private Map<String, Individual> individuals = new HashMap<>();
     private Map<String, Family> families = new HashMap<>();
+    
+    public GEDFile(Individual[] indivs, Family[] fams) {
+    	for (Individual indi : indivs) {
+    		individuals.put(indi.getID(), indi);
+    	}
+    	for (Family fam : fams) {
+    		families.put(fam.getID(), fam);
+    	}
+    }
 
     public GEDFile(File file) {
         Scanner s = null;

--- a/project/models/Individual.java
+++ b/project/models/Individual.java
@@ -16,15 +16,15 @@ public class Individual {
     private Date birthday;
     private Date death;
 
-    private List<String> children;
-    private List<String> spouse;
+    private List<String> famc;
+    private List<String> fams;
 
     public Individual(String ID) {
         this.ID = ID;
         this.name = "NA";
         this.gender = Gender.NA;
-        this.children = new ArrayList<>();
-        this.spouse = new ArrayList<>();
+        this.famc = new ArrayList<>();
+        this.fams = new ArrayList<>();
     }
 
     public String getID() {
@@ -63,20 +63,20 @@ public class Individual {
         this.death = death;
     }
 
-    public List<String> getChildren() {
-        return children;
+    public List<String> getChildrenFamily() {
+        return famc;
     }
 
-    public boolean addChild(String ID) {
-        return this.children.add(ID);
+    public boolean addChildFamily(String ID) {
+        return this.famc.add(ID);
     }
 
-    public List<String> getSpouse() {
-        return spouse;
+    public List<String> getSpouseFamily() {
+        return fams;
     }
 
-    public boolean addSpouse(String ID) {
-        return this.spouse.add(ID);
+    public boolean addSpouseFamily(String ID) {
+        return this.fams.add(ID);
     }
 
     public long age() {
@@ -98,6 +98,19 @@ public class Individual {
             throw new IllegalStateException();
         }
         return (death == null) ? true : false;
+    }
+    
+    public ArrayList<Individual> getChildren(Individual[] individuals) {
+    	ArrayList<Individual> myChildren = new ArrayList<Individual>();
+    	
+    	for (Individual indi : individuals) {
+    		// for each family where indi is a child, check if this is a spouse
+    		for(String famcStr : indi.famc) {
+    			if(this.fams.contains(famcStr)) myChildren.add(indi);
+    		}
+    	}
+    	
+    	return myChildren;
     }
 
 }

--- a/project/models/Individual.java
+++ b/project/models/Individual.java
@@ -1,6 +1,7 @@
 package project.models;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -100,7 +101,7 @@ public class Individual {
         return (death == null) ? true : false;
     }
     
-    public ArrayList<Individual> getChildren(Individual[] individuals) {
+    public Collection<Individual> getChildren(Collection<Individual> individuals) {
     	ArrayList<Individual> myChildren = new ArrayList<Individual>();
     	
     	for (Individual indi : individuals) {

--- a/project/tests/TestParentsNotTooOld.java
+++ b/project/tests/TestParentsNotTooOld.java
@@ -1,0 +1,83 @@
+package project.tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import project.Validator;
+import project.interfaces.Gender;
+import project.models.*;
+import project.validators.DefaultValidator;
+import project.validators.ParentsNotTooOld;
+
+import org.junit.jupiter.api.Test;
+
+class TestParentsNotTooOld {
+
+	Validator validator = new DefaultValidator();
+	Validator parentsNotTooOldValidator = new ParentsNotTooOld(validator);
+
+	@Test
+	void testParentsNotTooOldValidator() {
+		try {
+			Individual child1 = new Individual("Child1");
+			child1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/2020"));
+			child1.addChildFamily("Family1");
+
+			Individual father1 = new Individual("Father1");
+			father1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1940"));
+			father1.setGender(Gender.M);
+			father1.addSpouseFamily("Family1");
+
+			Individual mother1 = new Individual("Mother1");
+			mother1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1960"));
+			mother1.setGender(Gender.F);
+			mother1.addSpouseFamily("Family1");
+			
+			Individual[] individuals = {child1, father1, mother1};
+			Family[] families = {new Family("Family1")};
+			
+			// test at max age difference
+			assertTrue(parentsNotTooOldValidator.isValid(new GEDFile(individuals, families)));
+			
+			// test mother too old
+			mother1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1959"));
+			assertFalse(parentsNotTooOldValidator.isValid(new GEDFile(individuals, families)));
+			
+			// test father too old (and reset motherage)
+			mother1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1960"));
+			father1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1939"));
+			assertFalse(parentsNotTooOldValidator.isValid(new GEDFile(individuals, families)));	
+			
+			mother1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1980"));
+			father1.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/1980"));
+			
+			Individual child2 = new Individual("Child2");
+			child2.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/2020"));
+			child2.addChildFamily("Family1");
+			child2.addSpouseFamily("Family2");
+			child2.setGender(Gender.M);
+			
+			Individual grandchild = new Individual("grandchild1");
+			grandchild.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/2080"));
+			grandchild.addChildFamily("Family2");
+			
+			Individual[] individuals2 = {child1, father1, mother1, child2, grandchild};
+			Family[] families2 = {new Family("Family1"), new Family("Family2")};
+			// test with two families - a grandchild added
+			assertTrue(parentsNotTooOldValidator.isValid(new GEDFile(individuals2, families2)));
+			
+			// test for child-father too old for grandchild
+			grandchild.setBirthday(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/2110"));			
+			assertFalse(parentsNotTooOldValidator.isValid(new GEDFile(individuals2, families2)));
+			
+		} catch (ParseException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+
+	}
+
+}

--- a/project/validators/NoBigamy.java
+++ b/project/validators/NoBigamy.java
@@ -1,7 +1,7 @@
 package project.validators;
 
+import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import project.Validator;
@@ -18,11 +18,15 @@ public class NoBigamy extends Validator {
 
 		Map<String, Family> families = gedFile.getFamilies();
 		Map<String, Individual> individuals = gedFile.getIndividuals();
+		
+		Collection<Family> familyCollection = families.values();
+		Family[] familyArr = familyCollection.toArray(new Family[familyCollection.size()]);
 
-		for (Family baseFam : families.values()) {
-			for (Family testFam : families.values()) {
-				// Don't check marriage against itself
-				if (baseFam != testFam) {
+		for (int i = 0; i < families.values().size(); i++) {
+		    Family baseFam = familyArr[i];
+		    // + 1 prevents from baseFam being checked against itself
+		    for (int j = i + 1; j < families.values().size(); j++) {
+		    	Family testFam = familyArr[j];
 					// Only check marriages which share a husband or wife
 					if (baseFam.getHusband().equals(testFam.getHusband())
 							|| baseFam.getWife().equals(testFam.getWife())) {
@@ -66,7 +70,6 @@ public class NoBigamy extends Validator {
 					}
 				}
 			}
-		}
 
 		return valid;
 	}

--- a/project/validators/NoBigamy.java
+++ b/project/validators/NoBigamy.java
@@ -1,7 +1,11 @@
 package project.validators;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import project.Validator;
-import project.models.GEDFile;
+import project.models.*;
 
 public class NoBigamy extends Validator {
 
@@ -11,7 +15,59 @@ public class NoBigamy extends Validator {
 
 	protected boolean check(GEDFile gedFile) {
 		boolean valid = true;
-		// TODO
+
+		Map<String, Family> families = gedFile.getFamilies();
+		Map<String, Individual> individuals = gedFile.getIndividuals();
+
+		for (Family baseFam : families.values()) {
+			for (Family testFam : families.values()) {
+				// Don't check marriage against itself
+				if (baseFam != testFam) {
+					// Only check marriages which share a husband or wife
+					if (baseFam.getHusband().equals(testFam.getHusband())
+							|| baseFam.getWife().equals(testFam.getWife())) {
+
+						// Find earlier and later marriage
+						boolean isBaseEarlier = baseFam.getMarriage().before(testFam.getMarriage());
+						Family earlierFam = isBaseEarlier ? baseFam : testFam;
+						Family laterFam = !isBaseEarlier ? baseFam : testFam;
+
+						// If the earlier marriage has no divorce date, check death dates
+						if (earlierFam.getDivorce() == null) {
+							Date husbandDeath = individuals.get(earlierFam.getHusband()).getDeath();
+							Date wifeDeath = individuals.get(earlierFam.getHusband()).getDeath();
+
+							// if neither have died in the earlier marriage and there was no divorce, that's
+							// bigamy
+							if (husbandDeath == null && wifeDeath == null) {
+								// if neither spouse died or died after the second marriage, that's bigamy
+								System.out.println("Bigamy: Marriage " + earlierFam.getID()
+										+ " never got divorced and neither spouse died.");
+								valid = false;
+							}
+							// if either spouse DID die, make sure it's before later marriage
+							else if ((husbandDeath != null && husbandDeath.before(laterFam.getMarriage()))
+									|| (wifeDeath != null && wifeDeath.before(laterFam.getMarriage()))) {
+								System.out
+										.println("One spouse died in marriage " + earlierFam.getID() + " - not bigamy");
+							}
+						} 
+						// if the earlier marriage DOES have a divorce date, it must be before the later
+						// marriage date
+						else if (earlierFam.getDivorce().after(laterFam.getMarriage())) {
+							System.out.println("Bigamy: Earlier marriage " + earlierFam.getID() + " divorced on "
+									+ earlierFam.getDivorce() + " which is after " + laterFam.getID()
+									+ " marriage date " + laterFam.getMarriage());
+							valid = false;
+						} 
+						else {
+							System.out.println(earlierFam.getDivorce() + " is before " + laterFam.getMarriage() + " - not bigamy");
+						}
+					}
+				}
+			}
+		}
+
 		return valid;
 	}
 

--- a/project/validators/ParentsNotTooOld.java
+++ b/project/validators/ParentsNotTooOld.java
@@ -1,11 +1,10 @@
 package project.validators;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 import project.Validator;
 import project.interfaces.Gender;
-import project.models.Family;
 import project.models.GEDFile;
 import project.models.Individual;
 
@@ -21,7 +20,7 @@ public class ParentsNotTooOld extends Validator {
 		Map<String, Individual> individuals = gedFile.getIndividuals();
 		
 		for (Individual parent : individuals.values()) {
-			List<Individual> children = parent.getChildren(individuals.values().toArray(new Individual[individuals.values().size()]));
+			Collection<Individual> children = parent.getChildren(individuals.values());
 			if(children != null && children.size() > 0) {
 				int threshold = parent.getGender() == Gender.M ? 80 : 60;
 				

--- a/project/validators/ParentsNotTooOld.java
+++ b/project/validators/ParentsNotTooOld.java
@@ -1,0 +1,41 @@
+package project.validators;
+
+import java.util.List;
+import java.util.Map;
+
+import project.Validator;
+import project.interfaces.Gender;
+import project.models.Family;
+import project.models.GEDFile;
+import project.models.Individual;
+
+public class ParentsNotTooOld extends Validator {
+
+	public ParentsNotTooOld(Validator validator) {
+		super(validator);
+	}
+
+	protected boolean check(GEDFile gedFile) {
+		boolean valid = true;
+		
+		Map<String, Family> families = gedFile.getFamilies();
+		Map<String, Individual> individuals = gedFile.getIndividuals();
+		
+		for (Individual parent : individuals.values()) {
+			List<Individual> children = parent.getChildren(individuals.values().toArray(new Individual[individuals.values().size()]));
+			if(children != null && children.size() > 0) {
+				int threshold = parent.getGender() == Gender.M ? 80 : 60;
+				
+				for (Individual child : children) {
+					if(parent.age() - child.age() > threshold) {
+						System.out.println("Parent too old: Parent " + parent.getID() + " is more than " + threshold + " years older than child " + child.getID());
+						valid = false;
+					}
+				}
+			}
+		}
+		
+		return valid;
+	}
+
+}

--- a/project/validators/ParentsNotTooOld.java
+++ b/project/validators/ParentsNotTooOld.java
@@ -18,7 +18,6 @@ public class ParentsNotTooOld extends Validator {
 	protected boolean check(GEDFile gedFile) {
 		boolean valid = true;
 		
-		Map<String, Family> families = gedFile.getFamilies();
 		Map<String, Individual> individuals = gedFile.getIndividuals();
 		
 		for (Individual parent : individuals.values()) {

--- a/project/validators/Sample.java
+++ b/project/validators/Sample.java
@@ -1,0 +1,18 @@
+package project.validators;
+
+import project.Validator;
+import project.models.GEDFile;
+
+public class Sample extends Validator {
+
+	public Sample(Validator validator) {
+		super(validator);
+	}
+
+	protected boolean check(GEDFile gedFile) {
+		boolean valid = true;
+		// TODO
+		return valid;
+	}
+
+}


### PR DESCRIPTION
Renamed "children" and "spouse" on `Individual` class to "famc" and "fams" to match the GEDCOM labels. famc and fams are children where this individual is a child / spouse, not "children/spouses of this Individual," so this naming is more clear.

Added a `getChildren` method to Individual

Added NoBigamy and ParentsTooOld implementation